### PR TITLE
feat(better-blog-search): implement better articles fuzzy search

### DIFF
--- a/components/PostsSearch.tsx
+++ b/components/PostsSearch.tsx
@@ -8,11 +8,13 @@ export function PostsSearch({ onChange }: { onChange: (value: string) => void })
     <div className="relative max-w-lg">
       <input
         aria-label="Search posts"
-        type="text"
+        type="search"
         onChange={(e) => onChange(e.target.value)}
         placeholder={t('blog.search_posts')}
-        className="block w-full rounded-md border border-gray-300 bg-white pl-4 pr-10 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-800 dark:text-gray-100"
-        data-umami-event="post-search"
+        className="block appearance-none w-full rounded-md border border-gray-300 bg-white pl-4 pr-10 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-800 dark:text-gray-100"
+        spellCheck={false}
+        autoCorrect="off"
+        autoComplete="off"
       />
       <Search
         strokeWidth={1.5}

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  input[type='search']::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  input[type='search'].appearance-none {
+    -moz-appearance: textfield;
+  }
+}
+
 .remark-code-title {
   @apply rounded-t bg-gray-700 px-5 py-3 font-mono text-sm font-bold text-gray-200;
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "clsx": "^2.1.0",
     "esbuild": "^0.20.2",
     "framer-motion": "^11.2.12",
+    "fuzzysort": "^3.0.2",
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "i18next": "^23.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       framer-motion:
         specifier: ^11.2.12
         version: 11.2.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      fuzzysort:
+        specifier: ^3.0.2
+        version: 3.0.2
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3082,6 +3085,9 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuzzysort@3.0.2:
+    resolution: {integrity: sha512-ZyahVgxvckB1Qosn7YGWLDJJp2XlyaQ2WmZeI+d0AzW0AMqVYnz5N89G6KAKa6m/LOtv+kzJn4lhDF/yVg11Cg==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -8517,6 +8523,8 @@ snapshots:
       functions-have-names: 1.2.3
 
   functions-have-names@1.2.3: {}
+
+  fuzzysort@3.0.2: {}
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION
This PR refactors the way search was implemented on the blog page, and further enhances fuzzy search capabilities by bringing in a library called [`fuzzysort`](https://github.com/farzher/fuzzysort)